### PR TITLE
Search page

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -33,7 +33,7 @@ const getToken = async (authCode: string): Promise<string|null> => {
     saveToken('refreshToken', data.refresh_token)
     return data.access_token
   })
-  .catch(err => null)
+  .catch(err => Error('error'))
 }
 
 const getAuthToken =  async () => {

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -14,7 +14,7 @@ const getAuthCode = () => {
 }
 
 const saveToken = (key: string, token: string): void => {
-  sessionStorage.setItem(key, token);
+  if (token) sessionStorage.setItem(key, token);
 }
 
 const getToken = async (authCode: string): Promise<string|null> => {

--- a/src/components/SearchMusic/Albums/albumType.ts
+++ b/src/components/SearchMusic/Albums/albumType.ts
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export interface albumType {
+  id: string,
+  name: string,
+  artist: string,
+  image: {
+    height:number,
+    url: string,
+    width: number
+  }
+}
+
+export interface albumsJsonType {
+  albums: {
+    href: string,
+    items: albumsItems[],
+    limit: number,
+    next: string,
+    offset: number,
+    previous: string | null,
+    total: number
+  }
+}
+
+interface albumsItems {
+  album_type: string,
+  artists: artists[],
+  available_markets: string[],
+  external_urls: {[key: string]: string},
+  href: string,
+  id: string,
+  images: {
+      height: number,
+      url: string,
+      width: number
+  }[],
+  name: string,
+  release_date: string,
+  release_date_precision: string,
+  total_tracks: number,
+  type: string,
+  uri: string
+}
+
+interface artists {
+  external_urls: {[key: string]: string},
+  href: string,
+  id: string,
+  name: string,
+  type: string,
+  uri: string
+}

--- a/src/components/SearchMusic/Albums/albumType.ts
+++ b/src/components/SearchMusic/Albums/albumType.ts
@@ -23,7 +23,7 @@ export interface albumsJsonType {
   }
 }
 
-interface albumsItems {
+export interface albumsItems {
   album_type: string,
   artists: artists[],
   available_markets: string[],
@@ -43,7 +43,7 @@ interface albumsItems {
   uri: string
 }
 
-interface artists {
+export interface artists {
   external_urls: {[key: string]: string},
   href: string,
   id: string,

--- a/src/components/SearchMusic/Albums/index.tsx
+++ b/src/components/SearchMusic/Albums/index.tsx
@@ -1,0 +1,28 @@
+import React, {FC} from 'react';
+import {albumType} from './albumType';
+
+type Props = {
+  albums: albumType[]
+}
+
+const Albums: FC<Props> = ({albums}) => {
+  return (
+    <>
+      {
+        albums[0].id !== '' ? albums.map(album =>
+          <div key={album.id} className="album">
+            <img 
+              alt={album.name}
+              src={album.image === undefined ? undefined : album.image.url}
+            />
+            <h3>{album.name}</h3>
+            <p>By {album.artist}</p>
+          </div>
+        )
+        : <><p>Now Loading Album....</p></>
+      }
+    </>
+  )
+}
+
+export default Albums;

--- a/src/components/SearchMusic/Albums/useSearchAlbum.ts
+++ b/src/components/SearchMusic/Albums/useSearchAlbum.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import {albumType, albumsJsonType} from './albumType';
 
 export const useSearchAlbum = (token:string|null, searchInput:string):{albums: albumType[]} => {
-  const [albums, setAlbums] = useState([{
+  const [albums, setAlbums] = useState<albumType[]>([{
     id:'',
     name:'',
     artist:'',

--- a/src/components/SearchMusic/Albums/useSearchAlbum.ts
+++ b/src/components/SearchMusic/Albums/useSearchAlbum.ts
@@ -1,0 +1,36 @@
+import React, {useState, useEffect} from 'react';
+import axios from 'axios';
+import {albumType, albumsJsonType} from './albumType';
+
+export const useSearchAlbum = (token:string|null, searchInput:string):{albums: albumType[]} => {
+  const [albums, setAlbums] = useState([{
+    id:'',
+    name:'',
+    artist:'',
+    image: {
+      height: 0,
+      url: '',
+      width: 0
+    }
+  }])
+
+  const fetchAlbum = async ():Promise<albumType[]> => {
+    return await axios.get<albumsJsonType>(`https://api.spotify.com/v1/search?q=${searchInput}&type=album`, {
+      headers: {'Authorization' : 'Bearer ' + token}
+    })
+    .then(response => response.data)
+    .then(res => res.albums.items.map(item => ({
+      id: item.id,
+      name: item.name,
+      artist: item.artists[0].name,
+      image: item.images[1]
+    })))
+  }
+  useEffect(() => {
+    if (searchInput !== '') {
+      fetchAlbum().then(data => setAlbums(data))
+    }
+  }, [searchInput])
+
+  return {albums}
+}

--- a/src/components/SearchMusic/Artists/artistType.ts
+++ b/src/components/SearchMusic/Artists/artistType.ts
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export interface artistType {
+  id: string,
+  name: string,
+  image: {
+    height:number,
+    url: string,
+    width: number
+  }
+}
+
+export interface artistsJsonType {
+  artists: {
+    href: string,
+    items: artistsItems[],
+    limit: number,
+    next: string,
+    offset: number,
+    previous: string | null,
+    total: number
+  }
+}
+
+interface artistsItems {
+  external_urls: {}
+  followers: {
+    href: string,
+    total: number
+  }
+  genres: string[],
+  href: string,
+  id: string,
+  images: {
+      height: number,
+      url: string,
+      width: number
+  }[],
+  name: string,
+  popularity: number,
+  type: string,
+  uri: string
+}

--- a/src/components/SearchMusic/Artists/index.tsx
+++ b/src/components/SearchMusic/Artists/index.tsx
@@ -1,0 +1,27 @@
+import React, {FC} from 'react';
+import {artistType} from './artistType';
+
+type Props = {
+  artists: artistType[]
+}
+
+const Artists: FC<Props> = ({artists}) => {
+  return (
+    <> 
+      {
+        artists[0].id !== '' ? artists.map(artist =>
+          <div key={artist.id} className="artist">
+            <img 
+              alt={artist.name}
+              src={artist.image === undefined ? undefined : artist.image.url}
+            />
+            <p>{artist.name}</p>
+          </div>
+        )
+        : <><p>Now Loading Artist...</p></>
+      }
+    </>
+  )
+}
+
+export default Artists;

--- a/src/components/SearchMusic/Artists/useSearchArtist.ts
+++ b/src/components/SearchMusic/Artists/useSearchArtist.ts
@@ -1,0 +1,36 @@
+import React, {useState, useEffect} from 'react';
+import axios from 'axios';
+import {artistType, artistsJsonType} from './artistType';
+
+
+export const useSearchArtist = (token:string|null, searchInput:string):{artists: artistType[]} => {
+  const [artists, setArtists] = useState([{
+    id: '',
+    name: '',
+    image: {
+      height: 0,
+      url: '',
+      width: 0
+    }
+  }])
+
+  const fetchArtist = async ():Promise<artistType[]> => {
+    return await axios.get<artistsJsonType>(`https://api.spotify.com/v1/search?q=${searchInput}&type=artist`, {
+      headers: {'Authorization' : 'Bearer ' + token}
+    })
+    .then(response => response.data)
+    .then(res => res.artists.items.map(item => ({
+      id: item.id,
+      name: item.name,
+      image: item.images[1]
+    })))
+  }
+
+  useEffect(() => {
+    if (searchInput !== '') {
+      fetchArtist().then(data => setArtists(data))
+    }
+  }, [searchInput])
+
+  return {artists}
+}

--- a/src/components/SearchMusic/Artists/useSearchArtist.ts
+++ b/src/components/SearchMusic/Artists/useSearchArtist.ts
@@ -4,7 +4,7 @@ import {artistType, artistsJsonType} from './artistType';
 
 
 export const useSearchArtist = (token:string|null, searchInput:string):{artists: artistType[]} => {
-  const [artists, setArtists] = useState([{
+  const [artists, setArtists] = useState<artistType[]>([{
     id: '',
     name: '',
     image: {

--- a/src/components/SearchMusic/Tracks/index.tsx
+++ b/src/components/SearchMusic/Tracks/index.tsx
@@ -1,0 +1,24 @@
+import React, {FC} from 'react';
+import {trackType} from './trackType';
+
+type Props = {
+  tracks: trackType[]
+}
+
+const Tracks :FC<Props> = ({tracks}) => {
+  return (
+    <>
+      {
+        tracks[0].id !== '' ? tracks.map((track, idx) => 
+          <div key={track.id}>
+            <p>{idx + 1}</p>
+            <h4>{track.name}</h4>
+          </div>  
+        )
+        : <><p>Now Loading Tracks...</p></>
+      }
+    </>
+  )
+}
+
+export default Tracks;

--- a/src/components/SearchMusic/Tracks/trackType.ts
+++ b/src/components/SearchMusic/Tracks/trackType.ts
@@ -1,0 +1,40 @@
+import {albumsItems, artists} from '../Albums/albumType';
+
+export interface trackType {
+  id: string,
+  name: string,
+  artists: string,
+  playUrl: string | null,
+}
+
+export interface tracksJsonType {
+  tracks: {
+    href: string,
+    items: trackItems[],
+    limit: number,
+    next: string,
+    offset: number,
+    previous: string | null,
+    total: number
+  }
+}
+
+interface trackItems {
+  album: albumsItems,
+  artists: artists[],
+  avaiable_markets: string[],
+  disc_number: number,
+  duration_ms: number,
+  explicit: boolean,
+  external_ids: {[key: string]: string},
+  external_urls: {[key: string]: string}
+  href: string,
+  id: string,
+  is_local: boolean,
+  name: string,
+  popularity: number,
+  preview_url: string | null,
+  track_number: number,
+  type: string,
+  uri: string
+}

--- a/src/components/SearchMusic/Tracks/useSearchTrack.ts
+++ b/src/components/SearchMusic/Tracks/useSearchTrack.ts
@@ -1,0 +1,33 @@
+import React, {useState, useEffect} from 'react';
+import axios from 'axios';
+import {trackType, tracksJsonType} from './trackType';
+
+export const useSearchTrack = (token:string|null, searchInput:string):{tracks: trackType[]} => {
+  const [tracks, setTracks] = useState<trackType[]>([{
+    id: '',
+    name: '',
+    artists: '',
+    playUrl: '',
+  }])
+
+  const fetchTrack = async () => {
+    return await axios.get<tracksJsonType>(`https://api.spotify.com/v1/search?q=${searchInput}&type=track`, {
+      headers: {'Authorization' : 'Bearer ' + token}
+    })
+    .then(response => response.data)
+    .then(res => res.tracks.items.map(item => ({
+      id: item.id,
+      name: item.name,
+      artists: item.artists[0].name,
+      playUrl: item.preview_url,
+    })))
+  }
+
+  useEffect(() => {
+    if (searchInput !== '') {
+      fetchTrack().then(data => setTracks(data))
+    }
+  }, [searchInput])
+
+  return {tracks}
+}

--- a/src/components/SearchMusic/index.tsx
+++ b/src/components/SearchMusic/index.tsx
@@ -1,12 +1,36 @@
-import React, {FC, useState, useEffect} from 'react';
+import React, {FC, useState} from 'react';
 import Artists from './Artists';
+import Albums from './Albums';
+import Tracks from './Tracks';
 import {useSearch} from './useSearch';
 
+const ARTIST_PANEL = 'ARTIST_PANEL';
+const ALBUM_PANEL = 'ALBUM_PANEL';
+const TRACK_PANEL = 'TRACK_PANEL';
+
 const SearchMusic: FC = () => {
-  const [fetchData, {artists, albums}] = useSearch()
+  const [fetchData, {artists, albums, tracks}] = useSearch()
+  const [panel, setPanel] = useState(ARTIST_PANEL)
 
   const handleonChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     fetchData(e.target.value)
+  }
+  const handleOnClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    e.preventDefault()
+    setPanel(e.currentTarget.name)
+  }
+
+  const switchPanel = () => {
+    switch(panel) {
+      case ARTIST_PANEL:
+        return <Artists artists={artists}/>
+      case ALBUM_PANEL:
+        return <Albums albums={albums} />
+      case TRACK_PANEL:
+        return <Tracks tracks={tracks} />
+      default:
+        return null
+    }
   }
 
   return (
@@ -18,7 +42,15 @@ const SearchMusic: FC = () => {
         onChange={handleonChange}
       />
 
-      <Artists artists={artists} />
+      <div className="panel_button">
+        <button name={ARTIST_PANEL} onClick={handleOnClick}>Artists</button>
+        <button name={ALBUM_PANEL} onClick={handleOnClick}>Albums</button>
+        <button name={TRACK_PANEL} onClick={handleOnClick}>Tracks</button> 
+      </div>    
+
+      <div className="panel_display">
+        {switchPanel()}
+      </div>
     </div>
   )
 }

--- a/src/components/SearchMusic/index.tsx
+++ b/src/components/SearchMusic/index.tsx
@@ -1,97 +1,9 @@
 import React, {FC, useState, useEffect} from 'react';
-import {useHistory} from 'react-router-dom';
-import styled from 'styled-components';
-import axios from 'axios';
-
-interface artistType {
-  id: string,
-  name: string,
-  image: {
-    height:number,
-    url: string,
-    width: number
-  }
-}
-interface artistsItems {
-  external_urls: {}
-  followers: {
-    href: string,
-    total: number
-  }
-  genres: string[],
-  href: string,
-  id: string,
-  images: {
-      height: number,
-      url: string,
-      width: number
-  }[],
-  name: string,
-  popularity: number,
-  type: string,
-  uri: string
-}
-interface artistsJsonType {
-  artists: {
-    href: string,
-    items: artistsItems[],
-    limit: number,
-    next: string,
-    offset: number,
-    previous: string | null,
-    total: number
-  }
-}
-
-const useSearchArtist = ():[React.Dispatch<React.SetStateAction<string>>, {artists: artistType[]}] => {
-  const [searchInput, setSearchInput] = useState('')
-  const history = useHistory();
-  const [token, setToken] = useState<string | null>('')
-  const [artists, setArtists] = useState([{
-    id: '',
-    name: '',
-    image: {
-      height: 0,
-      url: '',
-      width: 0
-    }
-  }])
-  
-  const fetchArtist = async ():Promise<artistType[]> => {
-    return await axios.get<artistsJsonType>(`https://api.spotify.com/v1/search?q=${searchInput}&type=artist`, {
-      headers: {'Authorization' : 'Bearer ' + token}
-    })
-    .then(response => response.data)
-    .then(res => res.artists.items.map(item => ({
-      id: item.id,
-      name: item.name,
-      image: item.images[1]
-    })))
-  }
-
-  const getToken = async () => {
-    const checkToken = sessionStorage.getItem('accessToken')
-    if(!checkToken || checkToken === 'undefined') {
-      sessionStorage.removeItem('accessToken')
-      history.push('/')
-    }
-    await setToken(checkToken)
-  }
-  useEffect(() => {
-    if (searchInput !== '') {
-      fetchArtist().then(data => setArtists(data))
-    }
-  }, [searchInput])
-
-  useEffect(() => {
-    getToken()
-  })
-
-  return [setSearchInput, {artists}]
-}
+import Artists from './Artists';
+import {useSearch} from './useSearch';
 
 const SearchMusic: FC = () => {
-  const [fetchData, {artists}] = useSearchArtist();
+  const [fetchData, {artists, albums}] = useSearch()
 
   const handleonChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     fetchData(e.target.value)
@@ -106,19 +18,7 @@ const SearchMusic: FC = () => {
         onChange={handleonChange}
       />
 
-      {
-        artists[0].id !== '' ? artists.map(
-          artist =>
-            <div key={artist.id} className='artist'>
-              <img 
-                alt={artist.name}
-                src={artist.image === undefined ? undefined : artist.image.url}
-              />
-              <p>{artist.name}</p>
-            </div>
-        )
-        : <><p>Now Loading</p></>
-      }
+      <Artists artists={artists} />
     </div>
   )
 }

--- a/src/components/SearchMusic/index.tsx
+++ b/src/components/SearchMusic/index.tsx
@@ -1,9 +1,124 @@
-import React, {FC} from 'react';
+import React, {FC, useState, useEffect} from 'react';
+import {useHistory} from 'react-router-dom';
+import styled from 'styled-components';
+import axios from 'axios';
+
+interface artistType {
+  id: string,
+  name: string,
+  image: {
+    height:number,
+    url: string,
+    width: number
+  }
+}
+interface artistsItems {
+  external_urls: {}
+  followers: {
+    href: string,
+    total: number
+  }
+  genres: string[],
+  href: string,
+  id: string,
+  images: {
+      height: number,
+      url: string,
+      width: number
+  }[],
+  name: string,
+  popularity: number,
+  type: string,
+  uri: string
+}
+interface artistsJsonType {
+  artists: {
+    href: string,
+    items: artistsItems[],
+    limit: number,
+    next: string,
+    offset: number,
+    previous: string | null,
+    total: number
+  }
+}
+
+const useSearchArtist = ():[React.Dispatch<React.SetStateAction<string>>, {artists: artistType[]}] => {
+  const [searchInput, setSearchInput] = useState('')
+  const history = useHistory();
+  const [token, setToken] = useState<string | null>('')
+  const [artists, setArtists] = useState([{
+    id: '',
+    name: '',
+    image: {
+      height: 0,
+      url: '',
+      width: 0
+    }
+  }])
+  
+  const fetchArtist = async ():Promise<artistType[]> => {
+    return await axios.get<artistsJsonType>(`https://api.spotify.com/v1/search?q=${searchInput}&type=artist`, {
+      headers: {'Authorization' : 'Bearer ' + token}
+    })
+    .then(response => response.data)
+    .then(res => res.artists.items.map(item => ({
+      id: item.id,
+      name: item.name,
+      image: item.images[1]
+    })))
+  }
+
+  const getToken = async () => {
+    const checkToken = sessionStorage.getItem('accessToken')
+    if(!checkToken || checkToken === 'undefined') {
+      sessionStorage.removeItem('accessToken')
+      history.push('/')
+    }
+    await setToken(checkToken)
+  }
+  useEffect(() => {
+    if (searchInput !== '') {
+      fetchArtist().then(data => setArtists(data))
+    }
+  }, [searchInput])
+
+  useEffect(() => {
+    getToken()
+  })
+
+  return [setSearchInput, {artists}]
+}
 
 const SearchMusic: FC = () => {
+  const [fetchData, {artists}] = useSearchArtist();
+
+  const handleonChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    fetchData(e.target.value)
+  }
+
   return (
     <div>
       <h1>Search Page</h1>
+      <input 
+        autoFocus
+        placeholder="start typing..."
+        onChange={handleonChange}
+      />
+
+      {
+        artists[0].id !== '' ? artists.map(
+          artist =>
+            <div key={artist.id} className='artist'>
+              <img 
+                alt={artist.name}
+                src={artist.image === undefined ? undefined : artist.image.url}
+              />
+              <p>{artist.name}</p>
+            </div>
+        )
+        : <><p>Now Loading</p></>
+      }
     </div>
   )
 }

--- a/src/components/SearchMusic/useSearch.ts
+++ b/src/components/SearchMusic/useSearch.ts
@@ -1,0 +1,36 @@
+import React, {useState, useEffect} from 'react';
+import {useHistory} from 'react-router-dom';
+import {useSearchArtist} from './Artists/useSearchArtist';
+import {useSearchAlbum} from './Albums/useSearchAlbum';
+
+import {artistType} from './Artists/artistType';
+import {albumType} from './Albums/albumType';
+
+export const useSearch = (): [
+  React.Dispatch<React.SetStateAction<string>>,
+  {
+    artists: artistType[],
+    albums: albumType[],
+  }
+] => {
+  const [searchInput, setSearchInput] = useState('')
+  const history = useHistory();
+  const [token, setToken] = useState<string | null>('')
+  const {artists} = useSearchArtist(token, searchInput)
+  const {albums} = useSearchAlbum(token, searchInput)
+
+  const getToken = async () => {
+    const checkToken = sessionStorage.getItem('accessToken')
+    if(!checkToken) {
+      sessionStorage.removeItem('accessToken')
+      history.push('/')
+    }
+    await setToken(checkToken)
+  }
+
+  useEffect(() => {
+    getToken()
+  })
+
+  return [setSearchInput, {artists, albums}]
+}

--- a/src/components/SearchMusic/useSearch.ts
+++ b/src/components/SearchMusic/useSearch.ts
@@ -2,15 +2,18 @@ import React, {useState, useEffect} from 'react';
 import {useHistory} from 'react-router-dom';
 import {useSearchArtist} from './Artists/useSearchArtist';
 import {useSearchAlbum} from './Albums/useSearchAlbum';
+import {useSearchTrack} from './Tracks/useSearchTrack';
 
 import {artistType} from './Artists/artistType';
 import {albumType} from './Albums/albumType';
+import {trackType} from './Tracks/trackType';
 
 export const useSearch = (): [
   React.Dispatch<React.SetStateAction<string>>,
   {
     artists: artistType[],
     albums: albumType[],
+    tracks: trackType[],
   }
 ] => {
   const [searchInput, setSearchInput] = useState('')
@@ -18,6 +21,7 @@ export const useSearch = (): [
   const [token, setToken] = useState<string | null>('')
   const {artists} = useSearchArtist(token, searchInput)
   const {albums} = useSearchAlbum(token, searchInput)
+  const {tracks} = useSearchTrack(token, searchInput)
 
   const getToken = async () => {
     const checkToken = sessionStorage.getItem('accessToken')
@@ -32,5 +36,5 @@ export const useSearch = (): [
     getToken()
   })
 
-  return [setSearchInput, {artists, albums}]
+  return [setSearchInput, {artists, albums, tracks}]
 }

--- a/src/components/TopPage/index.tsx
+++ b/src/components/TopPage/index.tsx
@@ -8,8 +8,16 @@ const TopPage: FC = () => {
   const history = useHistory();
 
   useEffect(() => {
+    console.log("get token call")
     getAuthToken()
-    history.push('/search')
+    .then(token => {
+      if(token) history.push({
+        pathname: '/search',
+        state: {token: token}
+      })
+    })
+    .catch(err => console.log(err))
+    console.log('calling after get token call')
   }, [])
   /*
   useEffect (() => {

--- a/src/constants/actions.ts
+++ b/src/constants/actions.ts
@@ -1,6 +1,0 @@
-export const SEARCH_ITEM = 'SEARCH_ITEM';
-export const SELECT_PAGE = 'SELECT_PAGE';
-export const REQUEST_ITEM = 'REQUEST_ITEM';
-export const RECEIVE_ITEM = 'RECEIVE_ITEM';
-export const SAVE_TOKEN = 'SAVE_TOKEN';
-export const FETCH_DATA = 'FETCH_DATA';

--- a/src/constants/component.ts
+++ b/src/constants/component.ts
@@ -1,5 +1,0 @@
-// tab panel
-export const ARTIST_PANEL = 'ARTIST_PANEL';
-export const ALBUM_PANEL = 'ALBUM_PANEL';
-export const TRACK_PANEL = 'TRACK_PANEL';
-


### PR DESCRIPTION
Spotify APIに対して、検索を行うcomponentを作成した。
apiはそれぞれartist, album, trackのqueryを持っており、入力ごとに検索をかける。
入力値はsearchInputに保有し、それぞれのカスタムフックに依存してAPIを叩きにいく。
表示はタブで切り替えができるようになっている。

見栄え等はまだしていないので、今後していく。
また、tokenを持っていない時と期限切れしている時の処理がまだ不十分なので、今後の実装とする。