### PR TITLE
Fix/support router on ghpage

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,7 +6,7 @@ name: Release GitHub Page
 on:
   push:
     branches:
-      - master
+      - fix/support-router-on-ghpage
 
 # ジョブの定義
 jobs:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,7 +6,7 @@ name: Release GitHub Page
 on:
   push:
     branches:
-      - fix/support-router-on-ghpage
+      - master
 
 # ジョブの定義
 jobs:

--- a/public/404.html
+++ b/public/404.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Spotify Player</title>
     <script type="text/javascript">
-      var pathSegmentsToKeep = 0;
+      var pathSegmentsToKeep = 1;
 
       var l = window.location;
       l.replace(

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Spotify Player</title>
+    <script type="text/javascript">
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,18 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
+    <script type="text/javascript">
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) { 
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## React-routerにおけるURL直打ちの解消
外部からのcallbackでurlを直打ちした際に、元となるhtmlが見当たらないとか言われて404になるエラーの対応

自作404.htmlを作成し、リダイレクト先が存在するときに、urlを文字列で変換して、履歴に追加して更新する